### PR TITLE
Add build platforms

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -6,3 +6,7 @@ github:
   tooling_branch_name: main
 conda_build:
   pkg_format: '2'
+build_platform:
+  linux_64: linux_64
+  osx_64: osx_64
+  win_64: win_64


### PR DESCRIPTION
Attempting to add other platforms to `.ci_support`